### PR TITLE
Add role-specific interface pages and RAAC information

### DIFF
--- a/content/data/header.json
+++ b/content/data/header.json
@@ -1,94 +1,128 @@
 {
-    "logo": {
-        "url": "/images/logo-dark.svg",
-        "altText": "Logo dark",
-        "styles": {
-            "self": {
-                "margin": ["mr-3"]
-            }
-        },
-        "type": "ImageBlock"
+  "logo": {
+    "url": "/images/logo-dark.svg",
+    "altText": "Logo dark",
+    "styles": {
+      "self": {
+        "margin": [
+          "mr-3"
+        ]
+      }
     },
-    "primaryLinks": [
+    "type": "ImageBlock"
+  },
+  "primaryLinks": [
+    {
+      "label": "Pricing",
+      "url": "/pricing",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Blog",
+      "altText": "Blog",
+      "url": "/blog",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Careers",
+      "altText": "Careers page",
+      "url": "/careers",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Dropdown",
+      "altText": "Dropdown",
+      "links": [
         {
-            "label": "Pricing",
-            "url": "/pricing",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "secondary",
-            "type": "Link"
+          "label": "Dropdown item",
+          "url": "/",
+          "icon": "arrowRight",
+          "iconPosition": "right",
+          "style": "secondary",
+          "type": "Link"
         },
         {
-            "label": "Blog",
-            "altText": "Blog",
-            "url": "/blog",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "secondary",
-            "type": "Link"
+          "label": "Dropdown item",
+          "url": "/",
+          "icon": "arrowRight",
+          "iconPosition": "right",
+          "style": "secondary",
+          "type": "Link"
         },
         {
-            "label": "Careers",
-            "altText": "Careers page",
-            "url": "/careers",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "secondary",
-            "type": "Link"
-        },
-        {
-            "label": "Dropdown",
-            "altText": "Dropdown",
-            "links": [
-                {
-                    "label": "Dropdown item",
-                    "url": "/",
-                    "icon": "arrowRight",
-                    "iconPosition": "right",
-                    "style": "secondary",
-                    "type": "Link"
-                },
-                {
-                    "label": "Dropdown item",
-                    "url": "/",
-                    "icon": "arrowRight",
-                    "iconPosition": "right",
-                    "style": "secondary",
-                    "type": "Link"
-                },
-                {
-                    "label": "Dropdown item",
-                    "url": "/",
-                    "icon": "arrowRight",
-                    "iconPosition": "right",
-                    "style": "secondary",
-                    "type": "Link"
-                }
-            ],
-            "labelStyle": "secondary",
-            "type": "SubNav"
+          "label": "Dropdown item",
+          "url": "/",
+          "icon": "arrowRight",
+          "iconPosition": "right",
+          "style": "secondary",
+          "type": "Link"
         }
-    ],
-    "secondaryLinks": [
-        {
-            "label": "Sign up",
-            "altText": "Sign up",
-            "url": "https://app.netlify.com/signup",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "secondary",
-            "type": "Button"
-        },
-        {
-            "label": "Log in",
-            "url": "/",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "primary",
-            "type": "Button"
-        }
-    ],
-    "variant": "logo-left-primary-nav-centered",
-    "colors": "bg-light-fg-dark",
-    "type": "Header"
+      ],
+      "labelStyle": "secondary",
+      "type": "SubNav"
+    },
+    {
+      "label": "Patients",
+      "url": "/patients",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Chirurgiens",
+      "url": "/chirurgiens",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Admin",
+      "url": "/admin",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "RAAC",
+      "url": "/raac",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    }
+  ],
+  "secondaryLinks": [
+    {
+      "label": "Sign up",
+      "altText": "Sign up",
+      "url": "https://app.netlify.com/signup",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Button"
+    },
+    {
+      "label": "Log in",
+      "url": "/",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "primary",
+      "type": "Button"
+    }
+  ],
+  "variant": "logo-left-primary-nav-centered",
+  "colors": "bg-light-fg-dark",
+  "type": "Header"
 }

--- a/content/pages/admin.md
+++ b/content/pages/admin.md
@@ -1,0 +1,12 @@
+---
+title: Espace Administration
+slug: admin
+type: PageLayout
+sections:
+  - type: GenericSection
+    title:
+      text: Espace Administration
+      type: TitleBlock
+    text: >-
+      Gestion des utilisateurs, des contenus et des paramètres pour l'équipe administrative.
+---

--- a/content/pages/chirurgiens.md
+++ b/content/pages/chirurgiens.md
@@ -1,0 +1,12 @@
+---
+title: Espace Chirurgiens
+slug: chirurgiens
+type: PageLayout
+sections:
+  - type: GenericSection
+    title:
+      text: Espace Chirurgiens
+      type: TitleBlock
+    text: >-
+      Outils et protocoles pour accompagner les chirurgiens dans la prise en charge RAAC.
+---

--- a/content/pages/patients.md
+++ b/content/pages/patients.md
@@ -1,0 +1,12 @@
+---
+title: Espace Patients
+slug: patients
+type: PageLayout
+sections:
+  - type: GenericSection
+    title:
+      text: Espace Patients
+      type: TitleBlock
+    text: >-
+      Accédez aux informations, documents et ressources dédiés aux patients RAAC.
+---

--- a/content/pages/raac.md
+++ b/content/pages/raac.md
@@ -1,0 +1,69 @@
+---
+title: RAAC
+slug: raac
+type: PageLayout
+sections:
+  - type: GenericSection
+    title:
+      text: Réhabilitation Améliorée Après Chirurgie (RAAC)
+      type: TitleBlock
+    text: >-
+      La RAAC vise à optimiser la récupération du patient après une intervention chirurgicale.
+    actions:
+      - label: Espace Patients
+        url: /patients
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+      - label: Espace Chirurgiens
+        url: /chirurgiens
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+      - label: Espace Administration
+        url: /admin
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+    media:
+      url: /images/main-hero.jpg
+      altText: Illustration RAAC
+      type: ImageBlock
+  - type: GenericSection
+    title:
+      text: Présentation de la RAAC
+      type: TitleBlock
+    text: >-
+      Définition et principes : alimentation précoce, mobilisations rapides, gestion optimisée de la douleur.
+  - type: GenericSection
+    title:
+      text: Parcours patient en RAAC
+      type: TitleBlock
+    text: |
+      **Avant l’hospitalisation** : consultations, éducation thérapeutique, préparation physique et nutritionnelle.
+
+      **Jour de l’intervention** : accueil, protocoles spécifiques RAAC, anesthésie, recommandations immédiates.
+
+      **Après l’intervention** : rééducation, réalimentation, contrôle de la douleur, sortie précoce et suivi.
+  - type: GenericSection
+    title:
+      text: Rôle des acteurs
+      type: TitleBlock
+    text: >-
+      Équipe médicale et paramédicale (chirurgiens, anesthésistes, infirmiers, kinésithérapeutes, diététiciens) et implication du patient.
+  - type: GenericSection
+    title:
+      text: Documents et ressources
+      type: TitleBlock
+    text: >-
+      Guides téléchargeables, vidéos explicatives et témoignages de patients.
+  - type: GenericSection
+    title:
+      text: FAQ / Contact
+      type: TitleBlock
+    text: >-
+      Réponses aux questions fréquentes et coordonnées pour joindre l’équipe RAAC.
+---


### PR DESCRIPTION
## Summary
- add RAAC information page describing program and patient journey
- link RAAC page in site header navigation
- link RAAC page to patient, surgeon, and admin interfaces

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5dc1ebbb883288397d18e46e24d95