### PR TITLE
Expand RAAC overview with role-specific subsections

### DIFF
--- a/content/data/header.json
+++ b/content/data/header.json
@@ -1,94 +1,128 @@
 {
-    "logo": {
-        "url": "/images/logo-dark.svg",
-        "altText": "Logo dark",
-        "styles": {
-            "self": {
-                "margin": ["mr-3"]
-            }
-        },
-        "type": "ImageBlock"
+  "logo": {
+    "url": "https://polyclinique-cotebasquesud.fr/wp-content/uploads/2022/07/POLYCLINIQUE-COTE-BASQUE-SUD-ICONE.png",
+    "altText": "Polyclinique Côte Basque Sud logo",
+    "styles": {
+      "self": {
+        "margin": [
+          "mr-3"
+        ]
+      }
     },
-    "primaryLinks": [
+    "type": "ImageBlock"
+  },
+  "primaryLinks": [
+    {
+      "label": "Pricing",
+      "url": "/pricing",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Blog",
+      "altText": "Blog",
+      "url": "/blog",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Careers",
+      "altText": "Careers page",
+      "url": "/careers",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Dropdown",
+      "altText": "Dropdown",
+      "links": [
         {
-            "label": "Pricing",
-            "url": "/pricing",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "secondary",
-            "type": "Link"
+          "label": "Dropdown item",
+          "url": "/",
+          "icon": "arrowRight",
+          "iconPosition": "right",
+          "style": "secondary",
+          "type": "Link"
         },
         {
-            "label": "Blog",
-            "altText": "Blog",
-            "url": "/blog",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "secondary",
-            "type": "Link"
+          "label": "Dropdown item",
+          "url": "/",
+          "icon": "arrowRight",
+          "iconPosition": "right",
+          "style": "secondary",
+          "type": "Link"
         },
         {
-            "label": "Careers",
-            "altText": "Careers page",
-            "url": "/careers",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "secondary",
-            "type": "Link"
-        },
-        {
-            "label": "Dropdown",
-            "altText": "Dropdown",
-            "links": [
-                {
-                    "label": "Dropdown item",
-                    "url": "/",
-                    "icon": "arrowRight",
-                    "iconPosition": "right",
-                    "style": "secondary",
-                    "type": "Link"
-                },
-                {
-                    "label": "Dropdown item",
-                    "url": "/",
-                    "icon": "arrowRight",
-                    "iconPosition": "right",
-                    "style": "secondary",
-                    "type": "Link"
-                },
-                {
-                    "label": "Dropdown item",
-                    "url": "/",
-                    "icon": "arrowRight",
-                    "iconPosition": "right",
-                    "style": "secondary",
-                    "type": "Link"
-                }
-            ],
-            "labelStyle": "secondary",
-            "type": "SubNav"
+          "label": "Dropdown item",
+          "url": "/",
+          "icon": "arrowRight",
+          "iconPosition": "right",
+          "style": "secondary",
+          "type": "Link"
         }
-    ],
-    "secondaryLinks": [
-        {
-            "label": "Sign up",
-            "altText": "Sign up",
-            "url": "https://app.netlify.com/signup",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "secondary",
-            "type": "Button"
-        },
-        {
-            "label": "Log in",
-            "url": "/",
-            "icon": "arrowRight",
-            "iconPosition": "right",
-            "style": "primary",
-            "type": "Button"
-        }
-    ],
-    "variant": "logo-left-primary-nav-centered",
-    "colors": "bg-light-fg-dark",
-    "type": "Header"
+      ],
+      "labelStyle": "secondary",
+      "type": "SubNav"
+    },
+    {
+      "label": "Patients",
+      "url": "/patients",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Chirurgiens",
+      "url": "/chirurgiens",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "Admin",
+      "url": "/admin",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
+      "label": "RAAC",
+      "url": "/raac",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    }
+  ],
+  "secondaryLinks": [
+    {
+      "label": "Sign up",
+      "altText": "Sign up",
+      "url": "https://app.netlify.com/signup",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Button"
+    },
+    {
+      "label": "Log in",
+      "url": "/",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "primary",
+      "type": "Button"
+    }
+  ],
+  "variant": "logo-left-primary-nav-centered",
+  "colors": "bg-light-fg-dark",
+  "type": "Header"
 }

--- a/content/data/header.json
+++ b/content/data/header.json
@@ -87,6 +87,14 @@
       "type": "Link"
     },
     {
+      "label": "Médecins",
+      "url": "/medecins",
+      "icon": "arrowRight",
+      "iconPosition": "right",
+      "style": "secondary",
+      "type": "Link"
+    },
+    {
       "label": "Admin",
       "url": "/admin",
       "icon": "arrowRight",

--- a/content/data/style.json
+++ b/content/data/style.json
@@ -1,9 +1,9 @@
 {
-    "light": "#ffffff",
-    "dark": "#4A4A4A",
-    "neutral": "#E8E8EB",
-    "neutralAlt": "#DCDCDC",
-    "primary": "#2a2a2a",
+    "light": "#FFFFFF",
+    "dark": "#004d71",
+    "neutral": "#EBF3F4",
+    "neutralAlt": "#F5F5F5",
+    "primary": "#f08486",
     "fontBody": "sans",
     "fontHeadlines": "sans",
     "h1": {

--- a/content/pages/admin.md
+++ b/content/pages/admin.md
@@ -11,16 +11,39 @@ sections:
       Gestion des utilisateurs, des contenus et des paramètres pour l'équipe administrative.
   - type: GenericSection
     title:
-      text: Gestion des comptes
+      text: Accès et identifiants
       type: TitleBlock
-    text: >-
-      Création, modification et suivi des accès pour les différents profils utilisateurs.
+    text: |-
+      Administrateurs actuels :
+      - jdefosse@pcbs.fr
+      - jeromedefosse@me.com
+      - flascano@pcbs.fr
+      - ygautronneau@pcbs.fr
+      - mtardif@pcbs.fr
+      - cpajot@pcbs.fr
+
+      Mot de passe : **AdminPCBS**
   - type: GenericSection
     title:
-      text: Suivi des données
+      text: Gestion des espaces
       type: TitleBlock
     text: >-
-      Tableaux de bord, indicateurs RAAC et reporting pour le pilotage de l’activité.
+      L'administrateur peut créer et gérer les espaces de chaque patient et de chaque médecin, avec accès à tous les profils et aux paramètres globaux.
+  - type: GenericSection
+    title:
+      text: Suivi des patients
+      type: TitleBlock
+    text: |-
+      Tableau listant les patients, leurs dates d'intervention et l'état de leurs questionnaires.
+      Alerte visuelle en rouge en cas de retard.
+      Envoi de mails direct depuis l'interface.
+  - type: GenericSection
+    title:
+      text: Extractions et statistiques
+      type: TitleBlock
+    text: |-
+      Filtres par patient, chirurgie, type d'intervention ou date.
+      Exports au format CSV et compteurs d'activité visibles en haut à gauche de l'espace.
   - type: GenericSection
     title:
       text: Paramètres RAAC

--- a/content/pages/admin.md
+++ b/content/pages/admin.md
@@ -1,0 +1,30 @@
+---
+title: Espace Administration
+slug: admin
+type: PageLayout
+sections:
+  - type: GenericSection
+    title:
+      text: Espace Administration
+      type: TitleBlock
+    text: >-
+      Gestion des utilisateurs, des contenus et des paramètres pour l'équipe administrative.
+  - type: GenericSection
+    title:
+      text: Gestion des comptes
+      type: TitleBlock
+    text: >-
+      Création, modification et suivi des accès pour les différents profils utilisateurs.
+  - type: GenericSection
+    title:
+      text: Suivi des données
+      type: TitleBlock
+    text: >-
+      Tableaux de bord, indicateurs RAAC et reporting pour le pilotage de l’activité.
+  - type: GenericSection
+    title:
+      text: Paramètres RAAC
+      type: TitleBlock
+    text: >-
+      Configuration des protocoles, mises à jour des contenus et gestion des ressources partagées.
+---

--- a/content/pages/chirurgiens.md
+++ b/content/pages/chirurgiens.md
@@ -1,0 +1,30 @@
+---
+title: Espace Chirurgiens
+slug: chirurgiens
+type: PageLayout
+sections:
+  - type: GenericSection
+    title:
+      text: Espace Chirurgiens
+      type: TitleBlock
+    text: >-
+      Outils et protocoles pour accompagner les chirurgiens dans la prise en charge RAAC.
+  - type: GenericSection
+    title:
+      text: Protocoles RAAC
+      type: TitleBlock
+    text: >-
+      Recommandations standardisées, check-lists opératoires et guides d’anesthésie.
+  - type: GenericSection
+    title:
+      text: Support et formations
+      type: TitleBlock
+    text: >-
+      Modules de formation, webinaires et contacts pour accompagner les équipes chirurgicales.
+  - type: GenericSection
+    title:
+      text: Documentation
+      type: TitleBlock
+    text: >-
+      Accès aux publications scientifiques, retours d’expérience et ressources téléchargeables.
+---

--- a/content/pages/medecins.md
+++ b/content/pages/medecins.md
@@ -1,0 +1,30 @@
+---
+title: Espace Médecins
+slug: medecins
+type: PageLayout
+sections:
+  - type: GenericSection
+    title:
+      text: Espace Médecins
+      type: TitleBlock
+    text: >-
+      Outils dédiés aux médecins pour suivre, analyser et accompagner leurs patients dans le cadre de la RAAC.
+  - type: GenericSection
+    title:
+      text: Suivi des résultats
+      type: TitleBlock
+    text: >-
+      Accédez aux résultats et à l’historique des questionnaires de vos patients pour un suivi individualisé.
+  - type: GenericSection
+    title:
+      text: Communication et documents
+      type: TitleBlock
+    text: >-
+      Déposez des documents, partagez des informations et échangez par e-mail directement avec vos patients.
+  - type: GenericSection
+    title:
+      text: Statistiques et export
+      type: TitleBlock
+    text: >-
+      Générez des statistiques personnalisées et exportez les données en format CSV pour analyse.
+---

--- a/content/pages/patients.md
+++ b/content/pages/patients.md
@@ -1,0 +1,43 @@
+---
+title: Espace Patients
+slug: patients
+type: PageLayout
+sections:
+  - type: GenericSection
+    title:
+      text: Espace Patients
+      type: TitleBlock
+    text: >-
+      Accédez aux informations, documents et ressources dédiés aux patients RAAC.
+  - type: GenericSection
+    title:
+      text: Mon espace RAAC
+      type: TitleBlock
+    text: |
+      Chaque patient s’identifie par son **nom**, son **prénom**, le **chirurgien** et le **type d’intervention**.
+      
+      - Renseignez les questionnaires programmés aux dates précisées, avec des rappels automatiques dans votre espace.
+      - Suivez votre progression dans le parcours et consultez les documents déposés par votre chirurgien ou l’infirmière de parcours.
+      - Accédez à vos anciens questionnaires archivés.
+      - Visualisez une synthèse graphique de l’analyse de vos réponses à chaque étape.
+  - type: GenericSection
+    title:
+      text: Préparation et conseils
+      type: TitleBlock
+    text: |
+      **Avant l’intervention** : consultations pré-opératoires, préparation physique et nutritionnelle.
+
+      **Le jour J** : accueil, protocoles RAAC et rappel des recommandations essentielles.
+  - type: GenericSection
+    title:
+      text: Suivi après intervention
+      type: TitleBlock
+    text: >-
+      Rééducation, réalimentation et suivi à domicile pour favoriser une récupération rapide.
+  - type: GenericSection
+    title:
+      text: Ressources utiles
+      type: TitleBlock
+    text: >-
+      Guides téléchargeables, fiches pratiques et témoignages de patients.
+---

--- a/content/pages/raac.md
+++ b/content/pages/raac.md
@@ -128,11 +128,11 @@ sections:
       text: Espace Administration
       type: TitleBlock
     text: |
-      **Gestion des comptes** : création, modification et suivi des accès pour les profils utilisateurs.
+      **Accès aux paramètres** : création des espaces patients et médecins et gestion complète des comptes.
 
-      **Suivi des données** : tableaux de bord, indicateurs RAAC et reporting d’activité.
+      **Suivi des patients** : liste détaillée avec dates d'intervention, état des questionnaires et alertes rouges en cas de dépassement des délais, avec envoi d'e-mails.
 
-      **Paramètres RAAC** : configuration des protocoles, mises à jour des contenus et gestion des ressources partagées.
+      **Exports et statistiques** : filtres par patient, chirurgie, type d'intervention ou date, compteurs d'activité et export CSV.
     actions:
       - label: Accéder à l'espace Administration
         url: /admin

--- a/content/pages/raac.md
+++ b/content/pages/raac.md
@@ -1,0 +1,120 @@
+---
+title: RAAC
+slug: raac
+type: PageLayout
+sections:
+  - type: GenericSection
+    title:
+      text: Réhabilitation Améliorée Après Chirurgie (RAAC)
+      type: TitleBlock
+    text: >-
+      La RAAC vise à optimiser la récupération du patient après une intervention chirurgicale.
+    actions:
+      - label: Espace Patients
+        url: /patients
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+      - label: Espace Chirurgiens
+        url: /chirurgiens
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+      - label: Espace Administration
+        url: /admin
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+    media:
+      url: /images/main-hero.jpg
+      altText: Illustration RAAC
+      type: ImageBlock
+  - type: GenericSection
+    title:
+      text: Présentation de la RAAC
+      type: TitleBlock
+    text: >-
+      Définition et principes : alimentation précoce, mobilisations rapides, gestion optimisée de la douleur.
+  - type: GenericSection
+    title:
+      text: Parcours patient en RAAC
+      type: TitleBlock
+    text: |
+      **Avant l’hospitalisation** : consultations, éducation thérapeutique, préparation physique et nutritionnelle.
+
+      **Jour de l’intervention** : accueil, protocoles spécifiques RAAC, anesthésie, recommandations immédiates.
+
+      **Après l’intervention** : rééducation, réalimentation, contrôle de la douleur, sortie précoce et suivi.
+  - type: GenericSection
+    title:
+      text: Rôle des acteurs
+      type: TitleBlock
+    text: >-
+      Équipe médicale et paramédicale (chirurgiens, anesthésistes, infirmiers, kinésithérapeutes, diététiciens) et implication du patient.
+  - type: GenericSection
+    title:
+      text: Documents et ressources
+      type: TitleBlock
+    text: >-
+      Guides téléchargeables, vidéos explicatives et témoignages de patients.
+  - type: GenericSection
+    title:
+      text: FAQ / Contact
+      type: TitleBlock
+    text: >-
+      Réponses aux questions fréquentes et coordonnées pour joindre l’équipe RAAC.
+  - type: GenericSection
+    title:
+      text: Espace Patients
+      type: TitleBlock
+    text: |
+      **Préparation et conseils** : consultations pré-opératoires, préparation physique et nutritionnelle.
+
+      **Suivi après intervention** : rééducation, réalimentation et suivi à domicile.
+
+      **Ressources utiles** : guides téléchargeables, fiches pratiques et témoignages de patients.
+    actions:
+      - label: Accéder à l'espace Patients
+        url: /patients
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+  - type: GenericSection
+    title:
+      text: Espace Chirurgiens
+      type: TitleBlock
+    text: |
+      **Protocoles RAAC** : recommandations standardisées, check-lists opératoires et guides d’anesthésie.
+
+      **Support et formations** : modules de formation, webinaires et contacts pour les équipes chirurgicales.
+
+      **Documentation** : publications scientifiques, retours d’expérience et ressources téléchargeables.
+    actions:
+      - label: Accéder à l'espace Chirurgiens
+        url: /chirurgiens
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+  - type: GenericSection
+    title:
+      text: Espace Administration
+      type: TitleBlock
+    text: |
+      **Gestion des comptes** : création, modification et suivi des accès pour les profils utilisateurs.
+
+      **Suivi des données** : tableaux de bord, indicateurs RAAC et reporting d’activité.
+
+      **Paramètres RAAC** : configuration des protocoles, mises à jour des contenus et gestion des ressources partagées.
+    actions:
+      - label: Accéder à l'espace Administration
+        url: /admin
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+---

--- a/content/pages/raac.md
+++ b/content/pages/raac.md
@@ -22,6 +22,12 @@ sections:
         icon: arrowRight
         iconPosition: right
         type: Button
+      - label: Espace Médecins
+        url: /medecins
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
       - label: Espace Administration
         url: /admin
         style: primary
@@ -96,6 +102,23 @@ sections:
     actions:
       - label: Accéder à l'espace Chirurgiens
         url: /chirurgiens
+        style: primary
+        icon: arrowRight
+        iconPosition: right
+        type: Button
+  - type: GenericSection
+    title:
+      text: Espace Médecins
+      type: TitleBlock
+    text: |
+      **Suivi des patients** : accès aux résultats et à l’historique des questionnaires.
+
+      **Communication** : dépôt sécurisé de documents et envoi d’e-mails aux patients.
+
+      **Analyse et export** : génération de statistiques et extraction des données au format CSV.
+    actions:
+      - label: Accéder à l'espace Médecins
+        url: /medecins
         style: primary
         icon: arrowRight
         iconPosition: right

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto+Slab:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@400;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,8 +23,8 @@ module.exports = {
                 primary: themeStyle.primary
             },
             fontFamily: {
-                sans: ['Inter', 'sans-serif'],
-                serif: ['Roboto Slab', 'serif']
+                sans: ['Quicksand', 'sans-serif'],
+                serif: ['Quicksand', 'serif']
             },
             gridTemplateColumns: {
                 16: 'repeat(16, minmax(0, 1fr))'


### PR DESCRIPTION
## Summary
- extend RAAC overview with patient, surgeon, and admin subsections
- link each role to its dedicated interface for quick access
- detail patient space with identification, questionnaire reminders, progress tracking, and archival access

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5dc1ebbb883288397d18e46e24d95