### PR TITLE
feat: add admin management interface

### DIFF
--- a/content/pages/admin-info.md
+++ b/content/pages/admin-info.md
@@ -1,6 +1,6 @@
 ---
 title: Espace Administration
-slug: admin
+slug: admin-info
 type: PageLayout
 sections:
   - type: GenericSection

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
 
 const AuthContext = createContext();
 
@@ -20,6 +20,44 @@ export function AuthProvider({ children }) {
 
     const [users, setUsers] = useState(initialUsers);
     const [currentUser, setCurrentUser] = useState(null);
+
+    // Load persisted users and session
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        const storedUsers = localStorage.getItem('users');
+        if (storedUsers) {
+            try {
+                const parsed = JSON.parse(storedUsers);
+                setUsers((prev) => ({ ...prev, ...parsed }));
+            } catch (_) {
+                /* ignore parse errors */
+            }
+        }
+        const storedCurrent = localStorage.getItem('currentUser');
+        if (storedCurrent) {
+            try {
+                setCurrentUser(JSON.parse(storedCurrent));
+            } catch (_) {
+                /* ignore parse errors */
+            }
+        }
+    }, []);
+
+    // Persist user list
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        localStorage.setItem('users', JSON.stringify(users));
+    }, [users]);
+
+    // Persist current session
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        if (currentUser) {
+            localStorage.setItem('currentUser', JSON.stringify(currentUser));
+        } else {
+            localStorage.removeItem('currentUser');
+        }
+    }, [currentUser]);
 
     function registerUser({ name, email, password, profile }) {
         setUsers((prev) => ({

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -3,14 +3,22 @@ import { createContext, useContext, useState } from 'react';
 const AuthContext = createContext();
 
 export function AuthProvider({ children }) {
-    const [users, setUsers] = useState({
-        'admin@example.com': {
-            name: 'Admin',
-            email: 'admin@example.com',
-            password: 'admin',
-            profile: 'admin'
-        }
-    });
+    const defaultAdmins = [
+        'jdefosse@pcbs.fr',
+        'jeromedefosse@me.com',
+        'flascano@pcbs.fr',
+        'ygautronneau@pcbs.fr',
+        'mtardif@pcbs.fr',
+        'cpajot@pcbs.fr'
+    ];
+
+    const initialUsers = defaultAdmins.reduce((acc, email) => {
+        const name = email.split('@')[0];
+        acc[email] = { name, email, password: 'AdminPCBS', profile: 'admin' };
+        return acc;
+    }, {});
+
+    const [users, setUsers] = useState(initialUsers);
     const [currentUser, setCurrentUser] = useState(null);
 
     function registerUser({ name, email, password, profile }) {

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+    const [users, setUsers] = useState({
+        'admin@example.com': {
+            name: 'Admin',
+            email: 'admin@example.com',
+            password: 'admin',
+            profile: 'admin'
+        }
+    });
+    const [currentUser, setCurrentUser] = useState(null);
+
+    function registerUser({ name, email, password, profile }) {
+        setUsers((prev) => ({
+            ...prev,
+            [email]: { name, email, password, profile }
+        }));
+    }
+
+    function login(email, password) {
+        const user = users[email];
+        if (user && user.password === password) {
+            setCurrentUser(user);
+            return true;
+        }
+        return false;
+    }
+
+    function logout() {
+        setCurrentUser(null);
+    }
+
+    return (
+        <AuthContext.Provider value={{ users, currentUser, registerUser, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+}
+
+export function useAuth() {
+    return useContext(AuthContext);
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,5 +1,10 @@
 import '../css/main.css';
+import { AuthProvider } from '../context/AuthContext';
 
 export default function MyApp({ Component, pageProps }) {
-    return <Component {...pageProps} />;
+    return (
+        <AuthProvider>
+            <Component {...pageProps} />
+        </AuthProvider>
+    );
 }

--- a/src/pages/admin/index.js
+++ b/src/pages/admin/index.js
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import Link from 'next/link';
+import { useAuth } from '../../context/AuthContext';
+
+const rolePermissions = {
+    admin: ['patient', 'surgeon', 'admin'],
+    surgeon: ['patient'],
+    patient: []
+};
+
+export default function AdminPage() {
+    const { currentUser, registerUser, users } = useAuth();
+    const [form, setForm] = useState({ name: '', email: '', password: '', profile: 'patient' });
+
+    if (!currentUser || currentUser.profile !== 'admin') {
+        return (
+            <div className="p-6">
+                <p>Accès non autorisé.</p>
+                <Link href="/login" className="text-blue-500 underline">
+                    Se connecter
+                </Link>
+            </div>
+        );
+    }
+
+    function handleSubmit(e) {
+        e.preventDefault();
+        if (!rolePermissions[currentUser.profile].includes(form.profile)) {
+            return;
+        }
+        registerUser(form);
+        setForm({ name: '', email: '', password: '', profile: 'patient' });
+    }
+
+    return (
+        <div className="p-6">
+            <h1 className="text-2xl font-bold mb-4">Interface Administrateur</h1>
+            <form onSubmit={handleSubmit} className="mb-6">
+                <input
+                    className="border p-1 mr-2"
+                    type="text"
+                    placeholder="Nom"
+                    value={form.name}
+                    onChange={(e) => setForm({ ...form, name: e.target.value })}
+                    required
+                />
+                <input
+                    className="border p-1 mr-2"
+                    type="email"
+                    placeholder="Email"
+                    value={form.email}
+                    onChange={(e) => setForm({ ...form, email: e.target.value })}
+                    required
+                />
+                <input
+                    className="border p-1 mr-2"
+                    type="password"
+                    placeholder="Mot de passe"
+                    value={form.password}
+                    onChange={(e) => setForm({ ...form, password: e.target.value })}
+                    required
+                />
+                <select
+                    className="border p-1 mr-2"
+                    value={form.profile}
+                    onChange={(e) => setForm({ ...form, profile: e.target.value })}
+                >
+                    <option value="patient">Patient</option>
+                    <option value="surgeon">Chirurgien</option>
+                    <option value="admin">Administrateur</option>
+                </select>
+                <button type="submit" className="bg-blue-500 text-white px-3 py-1 rounded">
+                    Créer
+                </button>
+            </form>
+            <div className="grid grid-cols-3 gap-4">
+                {['patient', 'surgeon', 'admin'].map((profile) => (
+                    <div key={profile}>
+                        <h2 className="font-semibold capitalize mb-2">{profile}s</h2>
+                        <ul className="list-disc list-inside">
+                            {Object.values(users)
+                                .filter((u) => u.profile === profile)
+                                .map((user, idx) => (
+                                    <li key={idx}>{user.name}</li>
+                                ))}
+                        </ul>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/pages/admin/index.js
+++ b/src/pages/admin/index.js
@@ -73,20 +73,24 @@ export default function AdminPage() {
                     Créer
                 </button>
             </form>
-            <div className="grid grid-cols-3 gap-4">
-                {['patient', 'surgeon', 'admin'].map((profile) => (
-                    <div key={profile}>
-                        <h2 className="font-semibold capitalize mb-2">{profile}s</h2>
-                        <ul className="list-disc list-inside">
-                            {Object.values(users)
-                                .filter((u) => u.profile === profile)
-                                .map((user, idx) => (
-                                    <li key={idx}>{user.name}</li>
-                                ))}
-                        </ul>
-                    </div>
-                ))}
-            </div>
+            <table className="min-w-full border">
+                <thead>
+                    <tr>
+                        <th className="border px-2 py-1 text-left">Nom</th>
+                        <th className="border px-2 py-1 text-left">Email</th>
+                        <th className="border px-2 py-1 text-left">Profil</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {Object.values(users).map((user, idx) => (
+                        <tr key={idx}>
+                            <td className="border px-2 py-1">{user.name}</td>
+                            <td className="border px-2 py-1">{user.email}</td>
+                            <td className="border px-2 py-1 capitalize">{user.profile}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
         </div>
     );
 }

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useAuth } from '../context/AuthContext';
+
+export default function LoginPage() {
+    const { login, users } = useAuth();
+    const router = useRouter();
+    const [form, setForm] = useState({ email: '', password: '' });
+    const [error, setError] = useState('');
+
+    function handleSubmit(e) {
+        e.preventDefault();
+        if (login(form.email, form.password)) {
+            const profile = users[form.email].profile;
+            router.push(`/${profile}`);
+        } else {
+            setError('Identifiants invalides');
+        }
+    }
+
+    return (
+        <div className="p-6">
+            <h1 className="text-2xl font-bold mb-4">Connexion</h1>
+            {error && <p className="text-red-500 mb-2">{error}</p>}
+            <form onSubmit={handleSubmit}>
+                <input
+                    className="border p-1 mr-2"
+                    type="email"
+                    placeholder="Email"
+                    value={form.email}
+                    onChange={(e) => setForm({ ...form, email: e.target.value })}
+                    required
+                />
+                <input
+                    className="border p-1 mr-2"
+                    type="password"
+                    placeholder="Mot de passe"
+                    value={form.password}
+                    onChange={(e) => setForm({ ...form, password: e.target.value })}
+                    required
+                />
+                <button type="submit" className="bg-blue-500 text-white px-3 py-1 rounded">
+                    Se connecter
+                </button>
+            </form>
+        </div>
+    );
+}

--- a/src/pages/patient/index.js
+++ b/src/pages/patient/index.js
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { useAuth } from '../../context/AuthContext';
+
+export default function PatientPage() {
+    const { currentUser } = useAuth();
+
+    if (!currentUser || currentUser.profile !== 'patient') {
+        return (
+            <div className="p-6">
+                <p>Accès non autorisé.</p>
+                <Link href="/login" className="text-blue-500 underline">
+                    Se connecter
+                </Link>
+            </div>
+        );
+    }
+
+    return (
+        <div className="p-6">
+            <h1 className="text-2xl font-bold mb-4">Espace Patient</h1>
+            <p>Bienvenue {currentUser.name}</p>
+        </div>
+    );
+}

--- a/src/pages/surgeon/index.js
+++ b/src/pages/surgeon/index.js
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { useAuth } from '../../context/AuthContext';
+
+export default function SurgeonPage() {
+    const { currentUser } = useAuth();
+
+    if (!currentUser || currentUser.profile !== 'surgeon') {
+        return (
+            <div className="p-6">
+                <p>Accès non autorisé.</p>
+                <Link href="/login" className="text-blue-500 underline">
+                    Se connecter
+                </Link>
+            </div>
+        );
+    }
+
+    return (
+        <div className="p-6">
+            <h1 className="text-2xl font-bold mb-4">Espace Chirurgien</h1>
+            <p>Bienvenue {currentUser.name}</p>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add credential-based login and restrict pages by user role
- extend admin interface to create accounts with email and password
- protect admin, patient, and surgeon spaces from unauthorized access

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a83539d254832880c9ce55333a6a23