### PR TITLE
feat: add Codespaces devcontainer and scripts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "content-ops-starter",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+  "remoteUser": "node",
+  "postCreateCommand": "npm ci && npm i -g @stackbit/cli",
+  "forwardPorts": [3000, 8090],
+  "portsAttributes": {
+    "3000": { "label": "Next.js (web)" },
+    "8090": { "label": "Netlify Visual Editor (stackbit)" }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "streetsidesoftware.code-spell-checker"
+      ],
+      "settings": {
+        "editor.formatOnSave": true
+      }
+    }
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Dev: Next.js",
+      "type": "shell",
+      "command": "npm run dev:next",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Dev: Visual Editor",
+      "type": "shell",
+      "command": "npm run dev:ve",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "label": "Dev: Tout (Next+VE)",
+      "type": "shell",
+      "command": "npm run dev:all",
+      "isBackground": true,
+      "problemMatcher": []
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@ Netlify starter that's made for customization with a flexible content model, com
 
 **⚡ View demo:** [https://content-ops-starter.netlify.app/](https://content-ops-starter.netlify.app/)
 
+## 🚀 Démarrer dans GitHub Codespaces
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new/jeromedefosse/content-ops-starter?quickstart=1)
+
+1. Ouvrez le dépôt dans **Codespaces** (bouton ci-dessus).
+2. À l’ouverture, les dépendances sont installées et le CLI du **Netlify Visual Editor** est ajouté.
+3. Lancez le développement :
+   - Tout-en-un : `npm run dev:all`
+   - Ou séparé (comportement recommandé par le README d’origine) :
+     - `npm run dev` (Next.js)
+     - `stackbit dev` (Netlify Visual Editor)
+4. Les ports **3000** (site Next.js) et **8090** (Visual Editor) seront exposés automatiquement.
+
+### Variables d’environnement (Algolia)
+Ce starter propose une intégration **Algolia**. Créez l’app/index et définissez dans l’environnement :
+- `NEXT_PUBLIC_ALGOLIA_APP_ID`
+- `NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY`
+- `NEXT_PUBLIC_ALGOLIA_INDEX_NAME`
+
+Dans Codespaces : *Settings → Codespaces → Secrets* (ou via `.env` local, ne pas commiter).
+
 ## Table of Contents
 
 - [Deploying to Netlify](#deploying-to-netlify)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "0.1.0",
     "scripts": {
         "dev": "next dev",
+        "dev:next": "next dev -p 3000",
+        "dev:ve": "stackbit dev --port 8090",
+        "dev:all": "concurrently -n NEXT,VE -c auto \"npm:dev:next\" \"npm:dev:ve\"",
         "build": "next build",
         "start": "next start"
     },
@@ -31,7 +34,8 @@
         "@types/react-dom": "^19.1.1",
         "autoprefixer": "^10.4.19",
         "prettier": "^3.3.2",
-        "typescript": "^5.6.2"
+        "typescript": "^5.6.2",
+        "concurrently": "^9.1.0"
     },
     "main": "next.config.js"
 }


### PR DESCRIPTION
## Summary
- add GitHub Codespaces devcontainer with Node 20 and preinstalled Netlify Visual Editor CLI
- add npm scripts for Next.js and Visual Editor plus VS Code tasks
- document Codespaces usage and Algolia env vars in README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/concurrently)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aedd19640883289f5288331c3df638