### PR TITLE
feat: add CSV utilities

### DIFF
--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,216 +1,181 @@
 /**
- * csv.ts — utilitaires CSV *monofichier* sans dépendance
+ * csv.ts — single-file, stable CSV utilities with tests
  *
- * - Corrige l'ancienne RegExp non terminée dans csvEscape.
- * - Corrige la concaténation + point-virgule manquant dans toCsv.
- * - Gère valeurs null/undefined, Date, booléens, nombres, tableaux.
- * - Entête facultatif, BOM et séparateur configurables.
- * - Inclut un petit jeu de tests auto-exécutés (node/ts-node).
+ * Fixes prior SyntaxError issues by:
+ *  - Using a properly closed regular expression in csvEscape: /["\n,]/
+ *  - Ensuring every statement is correctly terminated with semicolons
+ *  - Simplifying string concatenation logic inside toCsv
+ *
+ * Features:
+ *  - csvEscape: RFC4180-style escaping (quotes, commas, newlines)
+ *  - toCsv: accepts rows of objects or arrays
+ *  - Options for custom headers, delimiter, line ending, BOM, includeHeader
+ *  - Deterministic header order
+ *  - Lightweight self-test runner; does not depend on external libs
  */
 
-export type Row = Record<string, unknown>;
-
-export interface Column {
-    /** clé dans l'objet (supporte "a.b.c" pour lecture profonde) */
-    key: string;
-    /** libellé d'entête (par défaut = key) */
-    header?: string;
-    /** formatage facultatif */
-    formatter?: (value: unknown, row: Row) => string;
-}
+export type CsvPrimitive = string | number | boolean | null | undefined | Date;
+export type CsvCell = CsvPrimitive | CsvPrimitive[];
+export type CsvRow = Record<string, CsvCell> | CsvCell[];
 
 export interface ToCsvOptions {
-    /** Séparateur de colonnes (par défaut ",") — pour Excel FR, utilisez ";" */
+    /** explicit header order; if omitted and rows are objects, headers are derived */
+    headers?: string[];
+    /** cell delimiter (default ',') */
     delimiter?: string;
-    /** Fin de ligne (par défaut "\r\n" conforme RFC4180) */
-    eol?: string;
-    /** Ajoute un BOM UTF-8 en tête (améliore compatibilité Excel) */
-    bom?: boolean;
-    /** Inclure la ligne d'entête (par défaut true) */
-    includeHeaders?: boolean;
+    /** line ending (default '\n') */
+    lineEnding?: string;
+    /** prepend UTF-8 BOM (default false) */
+    includeBom?: boolean;
+    /** include header row (default true when headers exist) */
+    includeHeader?: boolean;
 }
 
-/** Échappe une valeur pour CSV selon le séparateur choisi. */
-export function csvEscape(value: unknown, delimiter = ','): string {
-    if (value == null) return '';
-
-    // Normalisation en string
-    const s = Array.isArray(value)
-        ? value.map((v) => (v == null ? '' : String(v))).join('|')
-        : value instanceof Date
-          ? value.toISOString()
-          : typeof value === 'object'
-            ? JSON.stringify(value)
-            : String(value);
-
-    // Construire une RegExp qui déclenche la quotation si nécessaire
-    const rx = new RegExp(`["\n${escapeForCharClass(delimiter)}]`);
-    if (rx.test(s)) {
-        // Échapper les guillemets en doublant le caractère, puis entourer de guillemets
-        const doubled = s.replace(/"/g, '""');
-        return `"${doubled}"`;
-    }
-    return s;
+/**
+ * Convert a value into a CSV-safe string.
+ * - null/undefined -> ""
+ * - Date -> ISO string
+ * - Array of primitives -> joined with '|'
+ * - Other -> String(v)
+ *
+ * If the field contains a double-quote, comma or newline, the value is wrapped in quotes
+ * and internal quotes are doubled per RFC4180.
+ */
+export function csvEscape(v: CsvCell): string {
+    if (v == null) return '';
+    const normalize = (x: CsvPrimitive): string => (x instanceof Date ? x.toISOString() : String(x));
+    const s = Array.isArray(v) ? v.map(normalize).join('|') : normalize(v);
+    // Properly closed regex: /["\n,]/
+    return /["\n,]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 
-/** Génère un CSV à partir d'un tableau d'objets. */
-export function toCsv(rows: Row[], columns?: Column[], opts: ToCsvOptions = {}): string {
-    const delimiter = opts.delimiter ?? ',';
-    const eol = opts.eol ?? '\r\n';
-    const includeHeaders = opts.includeHeaders ?? true;
-
-    // Détection automatique des colonnes si non fournies (ordre stable)
-    const cols: Column[] = columns && columns.length ? columns.map((c) => ({ ...c })) : inferColumnsFromRows(rows);
-
-    // Construire l'entête
-    const headerLine = includeHeaders ? cols.map((c) => csvEscape(c.header ?? c.key, delimiter)).join(delimiter) : '';
-
-    // Lignes de données
-    const dataLines = rows.map((row) => {
-        const cells = cols.map((col) => {
-            const raw = pick(row, col.key);
-            const formatted = col.formatter ? col.formatter(raw, row) : raw;
-            return csvEscape(formatted, delimiter);
-        });
-        return cells.join(delimiter);
-    });
-
-    // Concaténation sûre, avec point-virgule pour terminer chaque instruction (évite les erreurs de parsing)
-    const lines: string[] = [];
-    if (includeHeaders) lines.push(headerLine);
-    lines.push(...dataLines);
-
-    let csv = lines.join(eol) + (lines.length ? eol : '');
-    if (opts.bom) csv = '\uFEFF' + csv; // BOM UTF-8
-
-    return csv;
-}
-
-/* --------------------------------- Helpers -------------------------------- */
-
-function escapeForCharClass(ch: string): string {
-    // Échappe les caractères spéciaux d'une char class RegExp
-    // Note: on échappe aussi l'espace au cas où un séparateur exotique serait utilisé.
-    return ch.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&').replace(/ /g, '\\s');
-}
-
-/** Récupère une valeur par chemin "a.b.c" (lecture profonde sécurisée). */
-function pick(obj: unknown, path: string): unknown {
-    if (obj == null) return undefined;
-    if (!path.includes('.')) return (obj as any)[path];
-    return path.split('.').reduce<any>((acc, key) => (acc ? acc[key] : undefined), obj as any);
-}
-
-/** Infère une liste de colonnes unique et ordonnée à partir des lignes. */
-function inferColumnsFromRows(rows: Row[]): Column[] {
+/** Detect headers from object rows in a deterministic order. */
+export function detectHeadersFromRows(rows: CsvRow[]): string[] {
     const seen = new Set<string>();
-    const keys: string[] = [];
-    for (const r of rows) {
-        for (const k of Object.keys(r)) {
+    const headers: string[] = [];
+    for (const row of rows) {
+        if (Array.isArray(row)) continue;
+        for (const k of Object.keys(row)) {
             if (!seen.has(k)) {
                 seen.add(k);
-                keys.push(k);
+                headers.push(k);
             }
         }
     }
-    return keys.map((k) => ({ key: k, header: k }));
+    return headers;
 }
 
-/* ---------------------------------- Tests ---------------------------------- */
+/** Convert rows (objects or arrays) to CSV string. */
+export function toCsv(rows: CsvRow[], options: ToCsvOptions = {}): string {
+    const delimiter = options.delimiter ?? ',';
+    const lineEnding = options.lineEnding ?? '\n';
+    const includeBom = options.includeBom ?? false;
+    let headers = options.headers ? [...options.headers] : detectHeadersFromRows(rows);
+
+    // Decide whether to include header line
+    const headerExists = headers.length > 0;
+    const includeHeader = options.includeHeader ?? headerExists;
+
+    const lines: string[] = [];
+
+    if (includeHeader && headerExists) {
+        lines.push(headers.map((h) => csvEscape(h)).join(delimiter));
+    }
+
+    for (const row of rows) {
+        if (Array.isArray(row)) {
+            // Row is an array of cells
+            lines.push(row.map(csvEscape).join(delimiter));
+        } else {
+            // Row is an object; ensure stable header order
+            if (!headerExists) {
+                headers = Object.keys(row);
+            }
+            const cells = headers.map((h) => csvEscape(row[h]));
+            lines.push(cells.join(delimiter));
+        }
+    }
+
+    const body = lines.join(lineEnding) + (lines.length ? lineEnding : '');
+    return includeBom ? '\uFEFF' + body : body;
+}
+
 /**
- * Exécuter avec:
- *   ts-node csv.ts
- * ou
- *   node --loader ts-node/esm csv.ts   (si projet ESM)
+ * =====================
+ * Minimal Test Harness
+ * =====================
+ *
+ * These tests run when this file is executed directly with ts-node or transpiled JS.
+ * They are additive and do not replace any existing project tests.
  */
-declare const require: any | undefined;
-declare const module: any | undefined;
-
-if (typeof require !== 'undefined' && typeof module !== 'undefined' && require.main === module) {
-    runTests();
+function assertEqual(actual: unknown, expected: unknown, msg?: string): void {
+    if (actual !== expected) {
+        throw new Error((msg ? msg + '\n' : '') + `Expected:\n${expected}\nActual:\n${actual}`);
+    }
 }
 
-function runTests(): void {
-    const assert = (cond: any, msg: string) => {
-        if (!cond) throw new Error('Test failed: ' + msg);
-    };
+function runSelfTests(): void {
+    const lf = '\n';
 
-    // Jeu de données
-    const rows: Row[] = [
-        { id: 1, nom: 'Dupont', note: 12.5, ok: true },
-        { id: 2, nom: 'Alice "A"', note: 9, ok: false },
-        { id: 3, nom: 'Bob, Jr', note: 15, ok: null },
-        { id: 4, nom: 'Line\nBreak', note: 10.25, tags: ['a', 'b'] },
-        { id: 5, nom: null, date: new Date('2024-01-02T03:04:05Z') }
+    // 1) Basic object rows, header inferred
+    const rows1: CsvRow[] = [
+        { id: 1, name: 'Alice', ok: true },
+        { id: 2, name: 'Bob, Jr.', ok: false }
     ];
+    const csv1 = toCsv(rows1);
+    assertEqual(csv1, ['id,name,ok', '1,Alice,true', '2,"Bob, Jr.",false', ''].join(lf), 'Basic object rows with inferred header');
 
-    // 1) Basique avec entête + virgule
-    {
-        const csv = toCsv(rows);
-        assert(csv.startsWith('id,nom,note,ok'), 'Entête par défaut attendu');
-        assert(csv.includes('"Alice ""A"""'), 'Guillemets internes doivent être doublés + quotés');
-        assert(csv.includes('"Bob, Jr"'), 'Virgule interne doit forcer la quotation');
-        assert(csv.includes('"Line\nBreak"'), 'Saut de ligne doit forcer la quotation');
-        assert(csv.endsWith('\r\n'), 'Doit se terminer par EOL');
+    // 2) Array rows (no header)
+    const rows2: CsvRow[] = [
+        ['a', 'b'],
+        ['c', 'd']
+    ];
+    const csv2 = toCsv(rows2, { includeHeader: false });
+    assertEqual(csv2, ['a,b', 'c,d', ''].join(lf), 'Array rows without header');
+
+    // 3) Quotes and newlines
+    const rows3: CsvRow[] = [{ text: 'He said "Hello"', note: 'line1\nline2' }];
+    const csv3 = toCsv(rows3);
+    assertEqual(csv3, ['text,note', '"He said ""Hello""","line1\nline2"', ''].join(lf), 'Escape quotes and newlines');
+
+    // 4) Nulls, undefined, booleans, numbers
+    const rows4: CsvRow[] = [{ a: null, b: undefined, c: 0, d: false }];
+    const csv4 = toCsv(rows4);
+    assertEqual(csv4, ['a,b,c,d', ',,0,false', ''].join(lf), 'Null/undefined handling');
+
+    // 5) Arrays join with '|'
+    const rows5: CsvRow[] = [{ tags: ['hip', 'knee'], score: 7 }];
+    const csv5 = toCsv(rows5);
+    assertEqual(csv5, ['tags,score', 'hip|knee,7', ''].join(lf), 'Array join with |');
+
+    // 6) Custom headers ordering
+    const rows6: CsvRow[] = [{ b: 2, a: 1 }];
+    const csv6 = toCsv(rows6, { headers: ['a', 'b'] });
+    assertEqual(csv6, ['a,b', '1,2', ''].join(lf), 'Custom header order');
+
+    // 7) Custom delimiter and no final newline
+    const rows7: CsvRow[] = [{ a: 'x', b: 'y' }];
+    const csv7 = toCsv(rows7, { delimiter: ';', lineEnding: '\n', includeBom: false });
+    assertEqual(csv7, ['a;b', 'x;y', ''].join(lf), 'Custom delimiter works');
+
+    // 8) BOM
+    const csv8 = toCsv(rows7, { includeBom: true });
+    assertEqual(csv8.startsWith('\uFEFF'), true, 'Includes BOM when requested');
+}
+
+// Execute tests only if this module is the entry point
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+if (typeof require !== 'undefined' && typeof module !== 'undefined' && require.main === module) {
+    try {
+        runSelfTests();
+        // eslint-disable-next-line no-console
+        console.log('csv.ts self-tests: OK');
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('csv.ts self-tests: FAILED');
+        // eslint-disable-next-line no-console
+        console.error(err);
+        process.exitCode = 1;
     }
-
-    // 2) Délimiteur point-virgule (compat Excel FR)
-    {
-        const csv = toCsv(rows, undefined, { delimiter: ';' });
-        assert(csv.startsWith('id;nom;note;ok'), "Entête avec ';'");
-        assert(csv.includes('"Bob, Jr"'), "Virgule interne ne change rien avec ';' mais reste quotée car charclass");
-    }
-
-    // 3) Colonnes explicitement ordonnées et formatteur
-    {
-        const csv = toCsv(
-            rows,
-            [
-                { key: 'id' },
-                { key: 'nom', header: 'Nom complet' },
-                { key: 'note', formatter: (v) => (v == null ? '' : Number(v).toFixed(2)) },
-                { key: 'tags' },
-                { key: 'date' }
-            ],
-            { delimiter: ',', includeHeaders: true, bom: true }
-        );
-
-        assert(csv.charCodeAt(0) === 0xfeff, 'BOM présent');
-        const lines = csv.slice(1).trim().split('\r\n'); // enlever BOM pour lire la 1ère ligne
-        assert(lines[0] === 'id,Nom complet,note,tags,date', 'Entête custom + ordre');
-        assert(lines[1].split(',')[2] === '12.50', 'Formatteur sur note (2 décimales)');
-        assert(lines[3].includes('"a|b"'), 'Tableaux joints par | et quotés');
-        assert(/2024-01-02T03:04:05\.000Z/.test(csv), 'Date en ISO');
-    }
-
-    // 4) Clés profondes
-    {
-        const rows2 = [{ a: { b: { c: 'x,y' } } }, { a: { b: { c: 'z"z' } } }];
-        const csv = toCsv(rows2, [{ key: 'a.b.c', header: 'deep' }]);
-        const ls = csv.trim().split('\r\n');
-        assert(ls[0] === 'deep', 'Entête simple');
-        assert(ls[1] === '"x,y"', 'Virgule -> quoté');
-        assert(ls[2] === '"z""z"', 'Guillemets doublés');
-    }
-
-    // 5) Ligne vide / options
-    {
-        const csv = toCsv([], undefined, { includeHeaders: false });
-        assert(csv === '', "Pas de lignes => string vide si pas d'entête");
-    }
-
-    // 6) Vérifie la RegExp dynamique: aucun crash, pas de syntax error
-    {
-        const weird = toCsv([{ x: 'ok' }], undefined, { delimiter: '|' });
-        assert(weird.includes('x'), "Fonctionne avec '|' comme séparateur");
-    }
-
-    // 7) Nulls & undefined
-    {
-        const csv = toCsv([{ a: null, b: undefined }]);
-        const data = csv.trim().split('\r\n')[1];
-        assert(data === ',', 'Null/undefined => vide');
-    }
-
-    console.log('✔ Tous les tests CSV ont réussi.');
 }

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,216 @@
+/**
+ * csv.ts — utilitaires CSV *monofichier* sans dépendance
+ *
+ * - Corrige l'ancienne RegExp non terminée dans csvEscape.
+ * - Corrige la concaténation + point-virgule manquant dans toCsv.
+ * - Gère valeurs null/undefined, Date, booléens, nombres, tableaux.
+ * - Entête facultatif, BOM et séparateur configurables.
+ * - Inclut un petit jeu de tests auto-exécutés (node/ts-node).
+ */
+
+export type Row = Record<string, unknown>;
+
+export interface Column {
+    /** clé dans l'objet (supporte "a.b.c" pour lecture profonde) */
+    key: string;
+    /** libellé d'entête (par défaut = key) */
+    header?: string;
+    /** formatage facultatif */
+    formatter?: (value: unknown, row: Row) => string;
+}
+
+export interface ToCsvOptions {
+    /** Séparateur de colonnes (par défaut ",") — pour Excel FR, utilisez ";" */
+    delimiter?: string;
+    /** Fin de ligne (par défaut "\r\n" conforme RFC4180) */
+    eol?: string;
+    /** Ajoute un BOM UTF-8 en tête (améliore compatibilité Excel) */
+    bom?: boolean;
+    /** Inclure la ligne d'entête (par défaut true) */
+    includeHeaders?: boolean;
+}
+
+/** Échappe une valeur pour CSV selon le séparateur choisi. */
+export function csvEscape(value: unknown, delimiter = ','): string {
+    if (value == null) return '';
+
+    // Normalisation en string
+    const s = Array.isArray(value)
+        ? value.map((v) => (v == null ? '' : String(v))).join('|')
+        : value instanceof Date
+          ? value.toISOString()
+          : typeof value === 'object'
+            ? JSON.stringify(value)
+            : String(value);
+
+    // Construire une RegExp qui déclenche la quotation si nécessaire
+    const rx = new RegExp(`["\n${escapeForCharClass(delimiter)}]`);
+    if (rx.test(s)) {
+        // Échapper les guillemets en doublant le caractère, puis entourer de guillemets
+        const doubled = s.replace(/"/g, '""');
+        return `"${doubled}"`;
+    }
+    return s;
+}
+
+/** Génère un CSV à partir d'un tableau d'objets. */
+export function toCsv(rows: Row[], columns?: Column[], opts: ToCsvOptions = {}): string {
+    const delimiter = opts.delimiter ?? ',';
+    const eol = opts.eol ?? '\r\n';
+    const includeHeaders = opts.includeHeaders ?? true;
+
+    // Détection automatique des colonnes si non fournies (ordre stable)
+    const cols: Column[] = columns && columns.length ? columns.map((c) => ({ ...c })) : inferColumnsFromRows(rows);
+
+    // Construire l'entête
+    const headerLine = includeHeaders ? cols.map((c) => csvEscape(c.header ?? c.key, delimiter)).join(delimiter) : '';
+
+    // Lignes de données
+    const dataLines = rows.map((row) => {
+        const cells = cols.map((col) => {
+            const raw = pick(row, col.key);
+            const formatted = col.formatter ? col.formatter(raw, row) : raw;
+            return csvEscape(formatted, delimiter);
+        });
+        return cells.join(delimiter);
+    });
+
+    // Concaténation sûre, avec point-virgule pour terminer chaque instruction (évite les erreurs de parsing)
+    const lines: string[] = [];
+    if (includeHeaders) lines.push(headerLine);
+    lines.push(...dataLines);
+
+    let csv = lines.join(eol) + (lines.length ? eol : '');
+    if (opts.bom) csv = '\uFEFF' + csv; // BOM UTF-8
+
+    return csv;
+}
+
+/* --------------------------------- Helpers -------------------------------- */
+
+function escapeForCharClass(ch: string): string {
+    // Échappe les caractères spéciaux d'une char class RegExp
+    // Note: on échappe aussi l'espace au cas où un séparateur exotique serait utilisé.
+    return ch.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&').replace(/ /g, '\\s');
+}
+
+/** Récupère une valeur par chemin "a.b.c" (lecture profonde sécurisée). */
+function pick(obj: unknown, path: string): unknown {
+    if (obj == null) return undefined;
+    if (!path.includes('.')) return (obj as any)[path];
+    return path.split('.').reduce<any>((acc, key) => (acc ? acc[key] : undefined), obj as any);
+}
+
+/** Infère une liste de colonnes unique et ordonnée à partir des lignes. */
+function inferColumnsFromRows(rows: Row[]): Column[] {
+    const seen = new Set<string>();
+    const keys: string[] = [];
+    for (const r of rows) {
+        for (const k of Object.keys(r)) {
+            if (!seen.has(k)) {
+                seen.add(k);
+                keys.push(k);
+            }
+        }
+    }
+    return keys.map((k) => ({ key: k, header: k }));
+}
+
+/* ---------------------------------- Tests ---------------------------------- */
+/**
+ * Exécuter avec:
+ *   ts-node csv.ts
+ * ou
+ *   node --loader ts-node/esm csv.ts   (si projet ESM)
+ */
+declare const require: any | undefined;
+declare const module: any | undefined;
+
+if (typeof require !== 'undefined' && typeof module !== 'undefined' && require.main === module) {
+    runTests();
+}
+
+function runTests(): void {
+    const assert = (cond: any, msg: string) => {
+        if (!cond) throw new Error('Test failed: ' + msg);
+    };
+
+    // Jeu de données
+    const rows: Row[] = [
+        { id: 1, nom: 'Dupont', note: 12.5, ok: true },
+        { id: 2, nom: 'Alice "A"', note: 9, ok: false },
+        { id: 3, nom: 'Bob, Jr', note: 15, ok: null },
+        { id: 4, nom: 'Line\nBreak', note: 10.25, tags: ['a', 'b'] },
+        { id: 5, nom: null, date: new Date('2024-01-02T03:04:05Z') }
+    ];
+
+    // 1) Basique avec entête + virgule
+    {
+        const csv = toCsv(rows);
+        assert(csv.startsWith('id,nom,note,ok'), 'Entête par défaut attendu');
+        assert(csv.includes('"Alice ""A"""'), 'Guillemets internes doivent être doublés + quotés');
+        assert(csv.includes('"Bob, Jr"'), 'Virgule interne doit forcer la quotation');
+        assert(csv.includes('"Line\nBreak"'), 'Saut de ligne doit forcer la quotation');
+        assert(csv.endsWith('\r\n'), 'Doit se terminer par EOL');
+    }
+
+    // 2) Délimiteur point-virgule (compat Excel FR)
+    {
+        const csv = toCsv(rows, undefined, { delimiter: ';' });
+        assert(csv.startsWith('id;nom;note;ok'), "Entête avec ';'");
+        assert(csv.includes('"Bob, Jr"'), "Virgule interne ne change rien avec ';' mais reste quotée car charclass");
+    }
+
+    // 3) Colonnes explicitement ordonnées et formatteur
+    {
+        const csv = toCsv(
+            rows,
+            [
+                { key: 'id' },
+                { key: 'nom', header: 'Nom complet' },
+                { key: 'note', formatter: (v) => (v == null ? '' : Number(v).toFixed(2)) },
+                { key: 'tags' },
+                { key: 'date' }
+            ],
+            { delimiter: ',', includeHeaders: true, bom: true }
+        );
+
+        assert(csv.charCodeAt(0) === 0xfeff, 'BOM présent');
+        const lines = csv.slice(1).trim().split('\r\n'); // enlever BOM pour lire la 1ère ligne
+        assert(lines[0] === 'id,Nom complet,note,tags,date', 'Entête custom + ordre');
+        assert(lines[1].split(',')[2] === '12.50', 'Formatteur sur note (2 décimales)');
+        assert(lines[3].includes('"a|b"'), 'Tableaux joints par | et quotés');
+        assert(/2024-01-02T03:04:05\.000Z/.test(csv), 'Date en ISO');
+    }
+
+    // 4) Clés profondes
+    {
+        const rows2 = [{ a: { b: { c: 'x,y' } } }, { a: { b: { c: 'z"z' } } }];
+        const csv = toCsv(rows2, [{ key: 'a.b.c', header: 'deep' }]);
+        const ls = csv.trim().split('\r\n');
+        assert(ls[0] === 'deep', 'Entête simple');
+        assert(ls[1] === '"x,y"', 'Virgule -> quoté');
+        assert(ls[2] === '"z""z"', 'Guillemets doublés');
+    }
+
+    // 5) Ligne vide / options
+    {
+        const csv = toCsv([], undefined, { includeHeaders: false });
+        assert(csv === '', "Pas de lignes => string vide si pas d'entête");
+    }
+
+    // 6) Vérifie la RegExp dynamique: aucun crash, pas de syntax error
+    {
+        const weird = toCsv([{ x: 'ok' }], undefined, { delimiter: '|' });
+        assert(weird.includes('x'), "Fonctionne avec '|' comme séparateur");
+    }
+
+    // 7) Nulls & undefined
+    {
+        const csv = toCsv([{ a: null, b: undefined }]);
+        const data = csv.trim().split('\r\n')[1];
+        assert(data === ',', 'Null/undefined => vide');
+    }
+
+    console.log('✔ Tous les tests CSV ont réussi.');
+}


### PR DESCRIPTION
## Summary
- add zero-dependency CSV utilities with configurable delimiters, headers, and BOM support
- include helper functions and self-contained tests

## Testing
- ⚠️ `npx ts-node src/utils/csv.ts` (dependency fetch forbidden)
- ⚠️ `npm test` (missing script: test)
- ✅ `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b02f283bfc83289d661fbc295682a1