### PR TITLE
feat: compute questionnaire results

### DIFF
--- a/src/components/blocks/FormBlock/CheckboxFormControl/index.tsx
+++ b/src/components/blocks/FormBlock/CheckboxFormControl/index.tsx
@@ -15,49 +15,47 @@ export default function CheckboxFormControl(props) {
 
     return (
         <div
-            className={classNames('sb-form-control', {
+            className={classNames('sb-form-control', 'inline-flex', 'items-center', {
                 'sm:col-span-2': width === 'full'
             })}
             data-sb-field-path={fieldPath}
         >
-            <div className="flex items-center">
-                <input
-                    id={name}
-                    className="sb-checkbox absolute h-6 w-6 appearance-none select-none opacity-0"
-                    type="checkbox"
-                    name={name}
-                    {...attr}
-                    {...(fieldPath && { 'data-sb-field-path': '.name#@id .name#@name' })}
-                />
-                {label && (
-                    <label
-                        id={labelId}
-                        className={classNames(
-                            'sb-label',
-                            'inline-block',
-                            'cursor-pointer',
-                            'pl-10',
-                            'relative',
-                            // Checkbox on left:
-                            'before:absolute',
-                            'before:h-6',
-                            'before:w-6',
-                            'before:leading-6',
-                            'before:left-0',
-                            'before:top-1/2',
-                            'before:-translate-y-1/2',
-                            'before:border',
-                            'before:border-current',
-                            'before:cursor-pointer',
-                            'before:text-center'
-                        )}
-                        htmlFor={name}
-                        {...(fieldPath && { 'data-sb-field-path': '.label .name#@for' })}
-                    >
-                        {label}
-                    </label>
-                )}
-            </div>
+            <input
+                id={name}
+                className="sb-checkbox absolute h-6 w-6 appearance-none select-none opacity-0"
+                type="checkbox"
+                name={name}
+                {...attr}
+                {...(fieldPath && { 'data-sb-field-path': '.name#@id .name#@name' })}
+            />
+            {label && (
+                <label
+                    id={labelId}
+                    className={classNames(
+                        'sb-label',
+                        'inline-block',
+                        'cursor-pointer',
+                        'pl-10',
+                        'relative',
+                        // Checkbox on left:
+                        'before:absolute',
+                        'before:h-6',
+                        'before:w-6',
+                        'before:leading-6',
+                        'before:left-0',
+                        'before:top-1/2',
+                        'before:-translate-y-1/2',
+                        'before:border',
+                        'before:border-current',
+                        'before:cursor-pointer',
+                        'before:text-center'
+                    )}
+                    htmlFor={name}
+                    {...(fieldPath && { 'data-sb-field-path': '.label .name#@for' })}
+                >
+                    {label}
+                </label>
+            )}
         </div>
     );
 }

--- a/src/components/blocks/FormBlock/index.tsx
+++ b/src/components/blocks/FormBlock/index.tsx
@@ -9,6 +9,13 @@ import { calculateQuestionnaireScore } from '../../../utils/calculate-questionna
 export default function FormBlock(props) {
     const formRef = React.createRef<HTMLFormElement>();
     const { fields = [], elementId, submitButton, className, styles = {}, 'data-sb-field-path': fieldPath } = props;
+    const [results, setResults] = React.useState<
+        | {
+              items: { label: string; value: FormDataEntryValue }[];
+              score: number;
+          }
+        | null
+    >(null);
 
     if (fields.length === 0) {
         return null;
@@ -18,9 +25,12 @@ export default function FormBlock(props) {
         event.preventDefault();
 
         const data = new FormData(formRef.current);
-        const value = Object.fromEntries(data.entries());
-        const score = calculateQuestionnaireScore(value);
-        alert(`Form data: ${JSON.stringify(value)}\nScore: ${score}`);
+        const values = Object.fromEntries(data.entries());
+        const items = fields
+            .filter((field) => field.name && values[field.name] !== undefined)
+            .map((field) => ({ label: field.label || field.name, value: values[field.name] }));
+        const score = calculateQuestionnaireScore(values);
+        setResults({ items, score });
     }
 
     return (
@@ -67,6 +77,24 @@ export default function FormBlock(props) {
             {submitButton && (
                 <div className={classNames('mt-8', 'flex', mapStyles({ justifyContent: styles?.self?.justifyContent ?? 'flex-start' }))}>
                     <SubmitButtonFormControl {...submitButton} {...(fieldPath && { 'data-sb-field-path': '.submitButton' })} />
+                </div>
+            )}
+            {results && (
+                <div className="mt-8 w-full" data-sb-field-path={fieldPath ? `${fieldPath}.results` : undefined}>
+                    <table className="min-w-full border-collapse">
+                        <tbody>
+                            {results.items.map((item) => (
+                                <tr key={item.label} className="border-t">
+                                    <th className="p-2 text-left">{item.label}</th>
+                                    <td className="p-2">{String(item.value)}</td>
+                                </tr>
+                            ))}
+                            <tr className="border-t font-semibold">
+                                <th className="p-2 text-left">Score</th>
+                                <td className="p-2">{results.score}</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             )}
         </form>

--- a/src/components/blocks/FormBlock/index.tsx
+++ b/src/components/blocks/FormBlock/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { getComponent } from '../../components-registry';
 import { mapStylesToClassNames as mapStyles } from '../../../utils/map-styles-to-class-names';
 import SubmitButtonFormControl from './SubmitButtonFormControl';
+import { calculateQuestionnaireScore } from '../../../utils/calculate-questionnaire-score';
 
 export default function FormBlock(props) {
     const formRef = React.createRef<HTMLFormElement>();
@@ -18,7 +19,8 @@ export default function FormBlock(props) {
 
         const data = new FormData(formRef.current);
         const value = Object.fromEntries(data.entries());
-        alert(`Form data: ${JSON.stringify(value)}`);
+        const score = calculateQuestionnaireScore(value);
+        alert(`Form data: ${JSON.stringify(value)}\nScore: ${score}`);
     }
 
     return (
@@ -43,7 +45,7 @@ export default function FormBlock(props) {
             id={elementId}
             onSubmit={handleSubmit}
             ref={formRef}
-            data-sb-field-path= {fieldPath}
+            data-sb-field-path={fieldPath}
         >
             <div
                 className={classNames('w-full', 'flex', 'flex-wrap', 'gap-8', mapStyles({ justifyContent: styles?.self?.justifyContent ?? 'flex-start' }))}

--- a/src/utils/calculate-questionnaire-score.ts
+++ b/src/utils/calculate-questionnaire-score.ts
@@ -1,0 +1,14 @@
+export function calculateQuestionnaireScore(values: Record<string, FormDataEntryValue>): number {
+    return Object.values(values).reduce((total, value) => {
+        if (typeof value === 'string') {
+            if (value === 'on') {
+                return total + 1;
+            }
+            const numeric = Number(value);
+            if (!isNaN(numeric)) {
+                return total + numeric;
+            }
+        }
+        return total;
+    }, 0);
+}


### PR DESCRIPTION
## Summary
- add utility to calculate questionnaire scores
- show computed score when forms submit
- display checkboxes inline within forms

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5a69d35108328a947d452069c2a2d